### PR TITLE
fix reject for resolved catch

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -72,7 +72,7 @@ class CustomPromise {
 
     const onRejectedReaction = (error) => {
       try {
-        reject(onRejectedHandler(error));
+        resolve(onRejectedHandler(error));
       } catch (e) {
         reject(e);
       }


### PR DESCRIPTION
Багуля: если в catch была обработка ошибки, то промис всё равно не разрешался.
```
const promise = new CustomPromise((resolve) => resolve());
const result = await promise
  .then(() => { throw new Error('Hello'); })
  .catch((error) => `${error.message}, World!`);
console.log(result); // Hello, World!
```